### PR TITLE
fix: allow value type to mismatch with column type

### DIFF
--- a/src/components/gui/table-cell/create-editable-cell.tsx
+++ b/src/components/gui/table-cell/create-editable-cell.tsx
@@ -123,7 +123,7 @@ export default function createEditableCell<T = unknown>({
 
     const applyChange = useCallback(
       (v: DatabaseValue<string>, shouldExitEdit = true) => {
-        if (onChange) onChange(toValue(v));
+        if (onChange) onChange(toValue(v) ?? (v as DatabaseValue<T>));
         if (shouldExitEdit) {
           state.exitEditMode();
         }


### PR DESCRIPTION
Due to SQLite flexibility, we can store _text_ in `INTEGER` fields, but this is currently impossible: when attempting to do so, the value is automatically converted to `NULL`.

Although this can be quite critical in some contexts, it is supported by SQLite as a 'non-bug'. If you already have fields with mismatched types, it becomes impossible to make any corrections because the value will always be converted to `NULL`. So, even though I'm personally not a big fan of this idea, it cannot be ignored.