### PR TITLE
feat: show only the selected database for outerbase cloud

### DIFF
--- a/src/app/(outerbase)/w/[workspaceId]/[baseId]/page.tsx
+++ b/src/app/(outerbase)/w/[workspaceId]/[baseId]/page.tsx
@@ -11,7 +11,8 @@ import {
 import DataCatalogExtension from "@/extensions/data-catalog";
 import OuterbaseExtension from "@/extensions/outerbase";
 import { getOuterbaseBase } from "@/outerbase-cloud/api";
-import { OuterbaseAPISource } from "@/outerbase-cloud/api-type";
+import { OuterbaseAPIBaseCredential } from "@/outerbase-cloud/api-type";
+import { getOuterbaseBaseCredential } from "@/outerbase-cloud/api-workspace";
 import DataCatalogOuterbaseDriver from "@/outerbase-cloud/data-catalog-driver";
 import { OuterbaseMySQLDriver } from "@/outerbase-cloud/database/mysql";
 import { OuterbasePostgresDriver } from "@/outerbase-cloud/database/postgresql";
@@ -26,7 +27,7 @@ export default function OuterbaseSourcePage() {
     baseId: string;
   }>();
   const [name, setName] = useState<string>("");
-  const [source, setSource] = useState<OuterbaseAPISource>();
+  const [credential, setCredential] = useState<OuterbaseAPIBaseCredential>();
 
   useEffect(() => {
     if (!workspaceId) return;
@@ -34,24 +35,27 @@ export default function OuterbaseSourcePage() {
 
     getOuterbaseBase(workspaceId, baseId).then((base) => {
       if (!base) return;
-      setSource(base.sources[0]);
+
       setName(base.name);
+      getOuterbaseBaseCredential(workspaceId, base.sources[0]?.id ?? "").then(
+        setCredential
+      );
     });
   }, [workspaceId, baseId]);
 
   const savedDocDriver = useMemo(() => {
-    if (!workspaceId || !source?.id || !baseId) return null;
-    return new OuterbaseQueryDriver(workspaceId, baseId, source.id);
-  }, [workspaceId, baseId, source?.id]);
+    if (!workspaceId || !credential?.id || !baseId) return null;
+    return new OuterbaseQueryDriver(workspaceId, baseId, credential.id);
+  }, [workspaceId, baseId, credential?.id]);
 
   const [outerbaseDriver, extensions] = useMemo(() => {
-    if (!workspaceId || !source) return [null, null];
+    if (!workspaceId || !credential) return [null, null];
 
-    const dialect = source.type;
+    const dialect = credential.type;
     const outerbaseConfig = {
       workspaceId,
-      sourceId: source.id,
-      baseId: source.base_id,
+      sourceId: credential.id,
+      baseId,
       token: localStorage.getItem("ob-token") ?? "",
     };
 
@@ -70,7 +74,7 @@ export default function OuterbaseSourcePage() {
       ];
     } else if (dialect === "mysql") {
       return [
-        new OuterbaseMySQLDriver(outerbaseConfig),
+        new OuterbaseMySQLDriver(outerbaseConfig, credential.database),
         new StudioExtensionManager([
           ...createMySQLExtensions(),
           ...outerbaseSpecifiedDrivers,
@@ -85,7 +89,7 @@ export default function OuterbaseSourcePage() {
         ...outerbaseSpecifiedDrivers,
       ]),
     ];
-  }, [workspaceId, source]);
+  }, [workspaceId, credential, baseId]);
 
   if (!outerbaseDriver || !savedDocDriver) {
     return <PageLoading>Loading Base ...</PageLoading>;

--- a/src/outerbase-cloud/api-type.ts
+++ b/src/outerbase-cloud/api-type.ts
@@ -62,6 +62,10 @@ export interface OuterbaseAPISourceInput {
   connection_id?: string;
 }
 
+export interface OuterbaseAPIBaseCredential extends OuterbaseAPISourceInput {
+  id: string;
+}
+
 export interface OuterbaseAPISource {
   model: "source";
   type: string;

--- a/src/outerbase-cloud/api-workspace.ts
+++ b/src/outerbase-cloud/api-workspace.ts
@@ -2,6 +2,7 @@ import { mutate } from "swr";
 import { requestOuterbase } from "./api";
 import {
   OuterbaseAPIBase,
+  OuterbaseAPIBaseCredential,
   OuterbaseAPIConnection,
   OuterbaseAPISource,
   OuterbaseAPISourceInput,
@@ -103,7 +104,7 @@ export async function getOuterbaseBaseCredential(
   workspaceId: string,
   sourceId: string
 ) {
-  return await requestOuterbase<OuterbaseAPISourceInput>(
+  return await requestOuterbase<OuterbaseAPIBaseCredential>(
     `/api/v1/workspace/${workspaceId}/source/${sourceId}/credential`,
     "GET"
   );

--- a/src/outerbase-cloud/database/mysql.ts
+++ b/src/outerbase-cloud/database/mysql.ts
@@ -15,9 +15,13 @@ export class OuterbaseMySQLDriver extends MySQLLikeDriver {
     };
   }
 
-  constructor({ workspaceId, sourceId }: OuterbaseDatabaseConfig) {
+  constructor(
+    { workspaceId, sourceId }: OuterbaseDatabaseConfig,
+    selectedDatabase?: string
+  ) {
     super();
 
+    this.selectedDatabase = selectedDatabase ?? "";
     this.workspaceId = workspaceId;
     this.sourceId = sourceId;
   }


### PR DESCRIPTION
We will not display other database tables when a user has specified a database in Outerbase Cloud. Since Outerbase Cloud does not run in interactive mode and does not support the USE statement, showing other databases would be unnecessary, as users cannot easily switch between them.