### PR TITLE
fix: set correct color theme on diagrams

### DIFF
--- a/src/components/gui/query-explanation-diagram/index.tsx
+++ b/src/components/gui/query-explanation-diagram/index.tsx
@@ -17,12 +17,14 @@ import { NestedLoop } from "./node-type/nested-loop";
 import { TableBlock } from "./node-type/table-block";
 import { OperationBlock } from "./node-type/operation-block";
 import { UnionBlock } from "./node-type/union-block";
+import { useTheme } from "next-themes";
 
 interface LayoutFlowProps {
   items: ExplanationMysql;
 }
 
 function QueryExplanationFlow(props: LayoutFlowProps) {
+  const { forcedTheme, resolvedTheme } = useTheme();
   const [loading, setLoading] = useState(true);
   const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
@@ -56,8 +58,11 @@ function QueryExplanationFlow(props: LayoutFlowProps) {
     }
   }, [props, loading, setEdges, setNodes]);
 
+  const appTheme = (forcedTheme ?? resolvedTheme) as "dark" | "light";
+
   return (
     <ReactFlow
+      colorMode={appTheme}
       nodes={nodes}
       edges={edges}
       onNodesChange={onNodesChange}

--- a/src/components/gui/tabs/relational-diagram-tab/index.tsx
+++ b/src/components/gui/tabs/relational-diagram-tab/index.tsx
@@ -27,6 +27,7 @@ import { useEffect, useState } from "react";
 import SchemaNameSelect from "../../schema-editor/schema-name-select";
 import { Toolbar } from "../../toolbar";
 import { DownloadImageDiagram } from "./download-image-diagram";
+import { useTheme } from "next-themes";
 
 const NODE_MARGIN = 50;
 const MAX_NODE_WIDTH = 300;
@@ -212,7 +213,7 @@ function mapSchema(
   const relationshipTopPosition =
     layoutRelationship.nodes.length === 0
       ? 0
-      : Math.min(...layoutRelationship.nodes.map((x) => x.position.y)) ?? 0;
+      : (Math.min(...layoutRelationship.nodes.map((x) => x.position.y)) ?? 0);
 
   // Calculate estimate area of the nodes without relationship
   const area =
@@ -279,6 +280,7 @@ function mapSchema(
 }
 
 function LayoutFlow() {
+  const { forcedTheme, resolvedTheme } = useTheme();
   const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
   const { schema: initialSchema, currentSchemaName, refresh } = useSchema();
@@ -296,6 +298,8 @@ function LayoutFlow() {
   const nodeTypes = {
     databaseSchema: DatabaseSchemaNode,
   };
+
+  const appTheme = (forcedTheme ?? resolvedTheme) as "dark" | "light";
 
   return (
     <div className="relative flex h-full flex-col overflow-hidden">
@@ -368,6 +372,7 @@ function LayoutFlow() {
       {selectedSchema && (
         <div className="relative flex-1 overflow-hidden">
           <ReactFlow
+            colorMode={appTheme}
             nodes={nodes}
             edges={edges}
             onNodesChange={onNodesChange}
@@ -375,7 +380,7 @@ function LayoutFlow() {
             fitView
             nodeTypes={nodeTypes}
           >
-            <Background />
+            <Background bgColor={appTheme === "dark" ? "#0a0a0a" : "white"} />
             <Controls />
             <MiniMap />
           </ReactFlow>


### PR DESCRIPTION
This pull request introduces improved theme support for the query explanation and relational diagram components.

It adds the theme obtained from the `useTheme` hook and applies the corresponding ReactFlow color mode. To maintain the same background color as before the change, the default dark mode background color is overridden.

|Before|After|
|---|---|
| <img width="1170" alt="SCR-20250308-qusj" src="https://github.com/user-attachments/assets/70a5a9b0-9867-4ed8-935a-82beee0e3ec2" /> | <img width="1171" alt="SCR-20250308-quwc" src="https://github.com/user-attachments/assets/1fe50bce-63f8-405f-9e58-cd87d3bf2061" /> |

