### PR TITLE
Rewrite the sqlite create script parser.

### DIFF
--- a/src/drivers/sqlite-base-driver.ts
+++ b/src/drivers/sqlite-base-driver.ts
@@ -325,6 +325,8 @@ export class SqliteLikeBaseDriver extends CommonSQLImplement {
     const schema = await this.tableSchema(schemaName, tableName);
     let injectRowIdColumn = false;
 
+    console.log(schema);
+
     // If there is no primary key, we will fallback to rowid.
     // But we need to make sure there is no rowid column
     if (

--- a/src/drivers/sqlite-base-driver.ts
+++ b/src/drivers/sqlite-base-driver.ts
@@ -325,8 +325,6 @@ export class SqliteLikeBaseDriver extends CommonSQLImplement {
     const schema = await this.tableSchema(schemaName, tableName);
     let injectRowIdColumn = false;
 
-    console.log(schema);
-
     // If there is no primary key, we will fallback to rowid.
     // But we need to make sure there is no rowid column
     if (

--- a/src/drivers/sqlite/sql-parse-constraint.test.ts
+++ b/src/drivers/sqlite/sql-parse-constraint.test.ts
@@ -1,0 +1,121 @@
+import type { DatabaseTableColumnConstraint } from "@/drivers/base-driver";
+import { tokenizeSql } from "@outerbase/sdk-transform";
+import { CursorV2, parseColumnConstraint } from "./sql-parse-table";
+
+// Parse column constraint
+function pcc(sql: string) {
+  return parseColumnConstraint(
+    "main",
+    new CursorV2(tokenizeSql(sql, "sqlite"))
+  );
+}
+
+describe("parse column constraint", () => {
+  test("constraint this_is_primary_key primary key autoincrement", () => {
+    expect(
+      pcc("constraint this_is_primary_key primary key autoincrement")
+    ).toEqual({
+      name: "this_is_primary_key",
+      primaryKey: true,
+      autoIncrement: true,
+    } as DatabaseTableColumnConstraint);
+  });
+  test("primary key with multiple columns", () => {
+    expect(pcc("primary key(first_name, last_name)")).toEqual({
+      primaryKey: true,
+      autoIncrement: false,
+      primaryColumns: ["first_name", "last_name"],
+    } as DatabaseTableColumnConstraint);
+  });
+
+  test("primary key with conflict clause and not null", () => {
+    expect(pcc("primary key on conflict rollback not null")).toEqual({
+      primaryKey: true,
+      autoIncrement: false,
+      primaryKeyConflict: "ROLLBACK",
+      notNull: true,
+    } as DatabaseTableColumnConstraint);
+  });
+
+  test("not null before primary key with conflict clause", () => {
+    expect(pcc("not null primary key on conflict rollback")).toEqual({
+      primaryKey: true,
+      autoIncrement: false,
+      primaryKeyConflict: "ROLLBACK",
+      notNull: true,
+    } as DatabaseTableColumnConstraint);
+  });
+
+  test("unique with conflict clause", () => {
+    expect(pcc("unique on conflict rollback")).toEqual({
+      unique: true,
+      uniqueConflict: "ROLLBACK",
+    } as DatabaseTableColumnConstraint);
+  });
+
+  test("default with string value", () => {
+    expect(pcc(`default 'Visal'`)).toEqual({
+      defaultValue: "Visal",
+    } as DatabaseTableColumnConstraint);
+  });
+
+  test("default with negative number", () => {
+    expect(pcc(`default -5`)).toEqual({
+      defaultValue: -5,
+    } as DatabaseTableColumnConstraint);
+  });
+
+  test("default with positive decimal", () => {
+    expect(pcc(`default +5.5`)).toEqual({
+      defaultValue: 5.5,
+    } as DatabaseTableColumnConstraint);
+  });
+
+  test("default with decimal", () => {
+    expect(pcc(`default 5.5`)).toEqual({
+      defaultValue: 5.5,
+    } as DatabaseTableColumnConstraint);
+  });
+
+  test("default with function", () => {
+    expect(pcc(`default current_timestamp`)).toEqual({
+      defaultExpression: "current_timestamp",
+    } as DatabaseTableColumnConstraint);
+  });
+
+  test("default with expression", () => {
+    expect(pcc(`default (round(julianday('now')))`)).toEqual({
+      defaultExpression: `round(julianday('now'))`,
+    } as DatabaseTableColumnConstraint);
+  });
+
+  test("foreign key with references", () => {
+    expect(
+      pcc(`foreign key ("user_id") references "users" on delete cascade ("id")`)
+    ).toEqual({
+      foreignKey: {
+        foreignSchemaName: "main",
+        columns: ["user_id"],
+        foreignTableName: "users",
+        foreignColumns: ["id"],
+      },
+    } as DatabaseTableColumnConstraint);
+  });
+
+  test("references shorthand", () => {
+    expect(pcc(`references "users" on delete cascade ("id")`)).toEqual({
+      foreignKey: {
+        foreignSchemaName: "main",
+        foreignTableName: "users",
+        foreignColumns: ["id"],
+      },
+    } as DatabaseTableColumnConstraint);
+  });
+
+  test("generated column", () => {
+    expect(pcc(`generated always as (price * qty) virtual`)).toEqual({
+      generatedExpression: "price * qty",
+      generatedType: "VIRTUAL",
+    } as DatabaseTableColumnConstraint);
+  });
+});

--- a/src/drivers/sqlite/sql-parse-table.test.ts
+++ b/src/drivers/sqlite/sql-parse-table.test.ts
@@ -1,107 +1,15 @@
-import type {
-  DatabaseTableColumnConstraint,
-  DatabaseTableSchema,
-} from "@/drivers/base-driver";
-import {
-  buildSyntaxCursor,
-  parseColumnConstraint,
-  parseCreateTableScript,
-} from "./sql-parse-table";
+import type { DatabaseTableSchema } from "@/drivers/base-driver";
+import { parseCreateTableScript } from "./sql-parse-table";
 
 // Parse column constraint
-function pcc(sql: string) {
-  return parseColumnConstraint("main", buildSyntaxCursor(sql));
-}
 
 function p(sql: string) {
   return parseCreateTableScript("main", sql);
 }
 
-it("parse column constraint", () => {
-  expect(
-    pcc("constraint this_is_primary_key primary key autoincrement")
-  ).toEqual({
-    name: "this_is_primary_key",
-    primaryKey: true,
-    autoIncrement: true,
-  } as DatabaseTableColumnConstraint);
-
-  expect(pcc("primary key(first_name, last_name)")).toEqual({
-    primaryKey: true,
-    autoIncrement: false,
-    primaryColumns: ["first_name", "last_name"],
-  } as DatabaseTableColumnConstraint);
-
-  expect(pcc("primary key on conflict rollback not null")).toEqual({
-    primaryKey: true,
-    autoIncrement: false,
-    primaryKeyConflict: "ROLLBACK",
-    notNull: true,
-  } as DatabaseTableColumnConstraint);
-
-  expect(pcc("not null primary key on conflict rollback")).toEqual({
-    primaryKey: true,
-    autoIncrement: false,
-    primaryKeyConflict: "ROLLBACK",
-    notNull: true,
-  } as DatabaseTableColumnConstraint);
-
-  expect(pcc("unique on conflict rollback")).toEqual({
-    unique: true,
-    uniqueConflict: "ROLLBACK",
-  } as DatabaseTableColumnConstraint);
-
-  expect(pcc(`default 'Visal'`)).toEqual({
-    defaultValue: "Visal",
-  } as DatabaseTableColumnConstraint);
-
-  expect(pcc(`default -5`)).toEqual({
-    defaultValue: -5,
-  } as DatabaseTableColumnConstraint);
-
-  expect(pcc(`default +5.5`)).toEqual({
-    defaultValue: 5.5,
-  } as DatabaseTableColumnConstraint);
-
-  expect(pcc(`default 5.5`)).toEqual({
-    defaultValue: 5.5,
-  } as DatabaseTableColumnConstraint);
-
-  expect(pcc(`default current_timestamp`)).toEqual({
-    defaultExpression: "current_timestamp",
-  } as DatabaseTableColumnConstraint);
-
-  expect(pcc(`default (round(julianday('now'))`)).toEqual({
-    defaultExpression: `(round(julianday('now'))`,
-  } as DatabaseTableColumnConstraint);
-
-  expect(
-    pcc(`foreign key ("user_id") references "users" on delete cascade ("id")`)
-  ).toEqual({
-    foreignKey: {
-      foreignSchemaName: "main",
-      columns: ["user_id"],
-      foreignTableName: "users",
-      foreignColumns: ["id"],
-    },
-  } as DatabaseTableColumnConstraint);
-
-  expect(pcc(`references "users" on delete cascade ("id")`)).toEqual({
-    foreignKey: {
-      foreignSchemaName: "main",
-      foreignTableName: "users",
-      foreignColumns: ["id"],
-    },
-  } as DatabaseTableColumnConstraint);
-
-  expect(pcc(`generated always as (price * qty) virtual`)).toEqual({
-    generatedExpression: "(price * qty)",
-    generatedType: "VIRTUAL",
-  } as DatabaseTableColumnConstraint);
-});
-
-it("parse create table", () => {
-  const sql = `create table "invoice_detail"(
+describe("parse create table", () => {
+  test("parse simple create table", () => {
+    const sql = `create table "invoice_detail"(
     id integer primary key autoincrement,
     product_id integer references product(id),
     price real not null,
@@ -110,62 +18,62 @@ it("parse create table", () => {
     total real generated always as (price * qty) virtual
   );`;
 
-  expect(p(sql)).toEqual({
-    tableName: "invoice_detail",
-    pk: ["id"],
-    autoIncrement: true,
-    constraints: [],
-    schemaName: "main",
-    columns: [
-      {
-        name: "id",
-        type: "integer",
-        pk: true,
-        constraint: {
-          primaryKey: true,
-          autoIncrement: true,
-        },
-      },
-      {
-        name: "product_id",
-        type: "integer",
-        constraint: {
-          foreignKey: {
-            foreignSchemaName: "main",
-            foreignTableName: "product",
-            foreignColumns: ["id"],
+    expect(p(sql)).toEqual({
+      tableName: "invoice_detail",
+      pk: ["id"],
+      autoIncrement: true,
+      constraints: [],
+      schemaName: "main",
+      columns: [
+        {
+          name: "id",
+          type: "integer",
+          pk: true,
+          constraint: {
+            primaryKey: true,
+            autoIncrement: true,
           },
         },
-      },
-      {
-        name: "price",
-        type: "real",
-        constraint: {
-          notNull: true,
+        {
+          name: "product_id",
+          type: "integer",
+          constraint: {
+            foreignKey: {
+              foreignSchemaName: "main",
+              foreignTableName: "product",
+              foreignColumns: ["id"],
+            },
+          },
         },
-      },
-      {
-        name: "qty",
-        type: "real",
-      },
-      {
-        name: "note",
-        type: "varchar(255)",
-      },
-      {
-        name: "total",
-        type: "real",
-        constraint: {
-          generatedExpression: "(price * qty)",
-          generatedType: "VIRTUAL",
+        {
+          name: "price",
+          type: "real",
+          constraint: {
+            notNull: true,
+          },
         },
-      },
-    ],
-  } as DatabaseTableSchema);
-});
+        {
+          name: "qty",
+          type: "real",
+        },
+        {
+          name: "note",
+          type: "varchar(255)",
+        },
+        {
+          name: "total",
+          type: "real",
+          constraint: {
+            generatedExpression: "price * qty",
+            generatedType: "VIRTUAL",
+          },
+        },
+      ],
+    } as DatabaseTableSchema);
+  });
 
-it("parse create table with table constraints", () => {
-  const sql = `create table "users"(
+  it("parse create table with table constraints", () => {
+    const sql = `create table "users"(
     first_name varchar,
     last_name varchar,
     category_id integer,
@@ -173,117 +81,117 @@ it("parse create table with table constraints", () => {
     foreign key(category_id) references category(id)
   );`;
 
-  expect(p(sql)).toEqual({
-    tableName: "users",
-    schemaName: "main",
-    pk: ["first_name", "last_name"],
-    autoIncrement: false,
-    constraints: [
-      {
-        primaryKey: true,
-        autoIncrement: false,
-        primaryColumns: ["first_name", "last_name"],
-      },
-      {
-        foreignKey: {
-          foreignSchemaName: "main",
-          columns: ["category_id"],
-          foreignColumns: ["id"],
-          foreignTableName: "category",
+    expect(p(sql)).toEqual({
+      tableName: "users",
+      schemaName: "main",
+      pk: ["first_name", "last_name"],
+      autoIncrement: false,
+      constraints: [
+        {
+          primaryKey: true,
+          autoIncrement: false,
+          primaryColumns: ["first_name", "last_name"],
         },
+        {
+          foreignKey: {
+            foreignSchemaName: "main",
+            columns: ["category_id"],
+            foreignColumns: ["id"],
+            foreignTableName: "category",
+          },
+        },
+      ],
+      columns: [
+        {
+          name: "first_name",
+          type: "varchar",
+          pk: true,
+        },
+        {
+          name: "last_name",
+          type: "varchar",
+          pk: true,
+        },
+        {
+          name: "category_id",
+          type: "integer",
+        },
+      ],
+    } as DatabaseTableSchema);
+  });
+
+  it("parse fts5 virtual table", () => {
+    const sql = `create virtual table name_fts using fts5(name, tokenize='trigram');`;
+    expect(p(sql)).toEqual({
+      tableName: "name_fts",
+      schemaName: "main",
+      autoIncrement: false,
+      pk: [],
+      columns: [],
+      constraints: [],
+      fts5: {},
+    } as DatabaseTableSchema);
+  });
+
+  it("parse fts5 virtual table with external content", () => {
+    const sql = `create virtual table name_fts using fts5(name, tokenize='trigram', content='student', content_rowid='id');`;
+    expect(p(sql)).toEqual({
+      tableName: "name_fts",
+      schemaName: "main",
+      autoIncrement: false,
+      pk: [],
+      columns: [],
+      constraints: [],
+      fts5: {
+        content: "'student'",
+        contentRowId: "'id'",
       },
-    ],
-    columns: [
-      {
-        name: "first_name",
-        type: "varchar",
-        pk: true,
-      },
-      {
-        name: "last_name",
-        type: "varchar",
-        pk: true,
-      },
-      {
-        name: "category_id",
-        type: "integer",
-      },
-    ],
-  } as DatabaseTableSchema);
-});
+    } as DatabaseTableSchema);
+  });
 
-it("parse fts5 virtual table", () => {
-  const sql = `create virtual table name_fts using fts5(name, tokenize='trigram');`;
-  expect(p(sql)).toEqual({
-    tableName: "name_fts",
-    schemaName: "main",
-    autoIncrement: false,
-    pk: [],
-    columns: [],
-    constraints: [],
-    fts5: {},
-  } as DatabaseTableSchema);
-});
+  it("parse without row id", () => {
+    const sql = `create table students(name text) without rowid;`;
+    expect(p(sql)).toEqual({
+      tableName: "students",
+      schemaName: "main",
+      autoIncrement: false,
+      pk: [],
+      columns: [{ name: "name", type: "text" }],
+      constraints: [],
+      withoutRowId: true,
+    } as DatabaseTableSchema);
+  });
 
-it("parse fts5 virtual table with external content", () => {
-  const sql = `create virtual table name_fts using fts5(name, tokenize='trigram', content='student', content_rowid='id');`;
-  expect(p(sql)).toEqual({
-    tableName: "name_fts",
-    schemaName: "main",
-    autoIncrement: false,
-    pk: [],
-    columns: [],
-    constraints: [],
-    fts5: {
-      content: "'student'",
-      contentRowId: "'id'",
-    },
-  } as DatabaseTableSchema);
-});
+  it("parse strict table", () => {
+    const sql = `create table students(name text) strict;`;
+    expect(p(sql)).toEqual({
+      tableName: "students",
+      schemaName: "main",
+      autoIncrement: false,
+      pk: [],
+      columns: [{ name: "name", type: "text" }],
+      constraints: [],
+      strict: true,
+    } as DatabaseTableSchema);
+  });
 
-it("parse without row id", () => {
-  const sql = `create table students(name text) without rowid;`;
-  expect(p(sql)).toEqual({
-    tableName: "students",
-    schemaName: "main",
-    autoIncrement: false,
-    pk: [],
-    columns: [{ name: "name", type: "text" }],
-    constraints: [],
-    withoutRowId: true,
-  } as DatabaseTableSchema);
-});
+  it("parse strict and without row id table", () => {
+    const sql = `create table students(name text) strict, without rowid;`;
+    expect(p(sql)).toEqual({
+      tableName: "students",
+      schemaName: "main",
+      autoIncrement: false,
+      pk: [],
+      columns: [{ name: "name", type: "text" }],
+      constraints: [],
+      strict: true,
+      withoutRowId: true,
+    } as DatabaseTableSchema);
+  });
 
-it("parse strict table", () => {
-  const sql = `create table students(name text) strict;`;
-  expect(p(sql)).toEqual({
-    tableName: "students",
-    schemaName: "main",
-    autoIncrement: false,
-    pk: [],
-    columns: [{ name: "name", type: "text" }],
-    constraints: [],
-    strict: true,
-  } as DatabaseTableSchema);
-});
-
-it("parse strict and without row id table", () => {
-  const sql = `create table students(name text) strict, without rowid;`;
-  expect(p(sql)).toEqual({
-    tableName: "students",
-    schemaName: "main",
-    autoIncrement: false,
-    pk: [],
-    columns: [{ name: "name", type: "text" }],
-    constraints: [],
-    strict: true,
-    withoutRowId: true,
-  } as DatabaseTableSchema);
-});
-
-// Regression test for https://github.com/outerbase/studio/issues/403
-it("parse table with foreign key and default", () => {
-  const sql = `CREATE TABLE "suggestions"(
+  // Regression test for https://github.com/outerbase/studio/issues/403
+  it("parse table with foreign key and default", () => {
+    const sql = `CREATE TABLE "suggestions"(
   "id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
   "entry" INTEGER NOT NULL REFERENCES "entries"("id"),
   "user" INTEGER NOT NULL REFERENCES "users"("id"),
@@ -291,60 +199,61 @@ it("parse table with foreign key and default", () => {
   "updatedAt" INTEGER NOT NULL DEFAULT (UNIXEPOCH())
 )`;
 
-  expect(p(sql)).toEqual({
-    tableName: "suggestions",
-    schemaName: "main",
-    autoIncrement: true,
-    pk: ["id"],
-    columns: [
-      {
-        name: "id",
-        type: "INTEGER",
-        pk: true,
-        constraint: { notNull: true, primaryKey: true, autoIncrement: true },
-      },
-      {
-        name: "entry",
-        type: "INTEGER",
-        constraint: {
-          notNull: true,
-          foreignKey: {
-            foreignSchemaName: "main",
-            foreignTableName: "entries",
-            foreignColumns: ["id"],
+    expect(p(sql)).toEqual({
+      tableName: "suggestions",
+      schemaName: "main",
+      autoIncrement: true,
+      pk: ["id"],
+      columns: [
+        {
+          name: "id",
+          type: "INTEGER",
+          pk: true,
+          constraint: { notNull: true, primaryKey: true, autoIncrement: true },
+        },
+        {
+          name: "entry",
+          type: "INTEGER",
+          constraint: {
+            notNull: true,
+            foreignKey: {
+              foreignSchemaName: "main",
+              foreignTableName: "entries",
+              foreignColumns: ["id"],
+            },
           },
         },
-      },
-      {
-        name: "user",
-        type: "INTEGER",
-        constraint: {
-          notNull: true,
-          foreignKey: {
-            foreignSchemaName: "main",
-            foreignTableName: "users",
-            foreignColumns: ["id"],
+        {
+          name: "user",
+          type: "INTEGER",
+          constraint: {
+            notNull: true,
+            foreignKey: {
+              foreignSchemaName: "main",
+              foreignTableName: "users",
+              foreignColumns: ["id"],
+            },
           },
         },
-      },
-      {
-        name: "scoreBy",
-        type: "INTEGER",
-        constraint: {
-          foreignKey: {
-            foreignSchemaName: "main",
-            foreignTableName: "users",
-            foreignColumns: ["id"],
+        {
+          name: "scoreBy",
+          type: "INTEGER",
+          constraint: {
+            foreignKey: {
+              foreignSchemaName: "main",
+              foreignTableName: "users",
+              foreignColumns: ["id"],
+            },
+            defaultExpression: "NULL",
           },
-          defaultExpression: "NULL",
         },
-      },
-      {
-        name: "updatedAt",
-        type: "INTEGER",
-        constraint: { notNull: true, defaultExpression: "(UNIXEPOCH())" },
-      },
-    ],
-    constraints: [],
-  } as DatabaseTableSchema);
+        {
+          name: "updatedAt",
+          type: "INTEGER",
+          constraint: { notNull: true, defaultExpression: "UNIXEPOCH()" },
+        },
+      ],
+      constraints: [],
+    } as DatabaseTableSchema);
+  });
 });

--- a/src/drivers/sqlite/sql-parse-trigger.test.ts
+++ b/src/drivers/sqlite/sql-parse-trigger.test.ts
@@ -20,7 +20,7 @@ function generateSql({
     CREATE TRIGGER ${name}
     ${whenString}${operation}${columnNameString} ON ${tableName}
     BEGIN
-      ${statement};
+      ${statement}
     END;
   `;
 }
@@ -44,14 +44,19 @@ describe("parse trigger", () => {
 
     const insert = parseCreateTriggerScript(
       "main",
-      generateSql({ name, operation: "INSERT", tableName, statement })
+      generateSql({
+        name,
+        operation: "INSERT",
+        tableName,
+        statement: statement + statement,
+      })
     );
     expect(insert).toMatchObject({
       name: name,
       when: "BEFORE",
       operation: "INSERT",
       tableName: tableName,
-      statement: statement,
+      statement: statement + statement,
     });
 
     const updateOf = parseCreateTriggerScript(

--- a/src/drivers/sqlite/sql-parse-view.test.ts
+++ b/src/drivers/sqlite/sql-parse-view.test.ts
@@ -1,0 +1,89 @@
+import { parseCreateViewScript } from "./sql-parse-view";
+
+describe("parse", () => {
+  test("parsing simple view", () => {
+    const view = parseCreateViewScript(
+      "main",
+      `CREATE VIEW COMPANY_VIEW AS SELECT ID, NAME, AGE FROM COMPANY;`
+    );
+    expect(view).toMatchObject({
+      schemaName: "main",
+      name: "COMPANY_VIEW",
+      statement: "SELECT ID, NAME, AGE FROM COMPANY",
+    });
+  });
+
+  test("parsing view with temporary keyword", () => {
+    const view = parseCreateViewScript(
+      "main",
+      `CREATE TEMPORARY VIEW TEMP_VIEW AS SELECT * FROM USERS;`
+    );
+    expect(view).toMatchObject({
+      schemaName: "main",
+      name: "TEMP_VIEW",
+      statement: "SELECT * FROM USERS",
+    });
+  });
+
+  test("parsing view with temp keyword", () => {
+    const view = parseCreateViewScript(
+      "main",
+      `CREATE TEMP VIEW TEMP_VIEW AS SELECT * FROM USERS;`
+    );
+    expect(view).toMatchObject({
+      schemaName: "main",
+      name: "TEMP_VIEW",
+      statement: "SELECT * FROM USERS",
+    });
+  });
+
+  test("parsing view with IF NOT EXISTS", () => {
+    const view = parseCreateViewScript(
+      "custom",
+      `CREATE VIEW IF NOT EXIST USER_STATS AS SELECT COUNT(*) AS user_count FROM USERS;`
+    );
+    expect(view).toMatchObject({
+      schemaName: "custom",
+      name: "USER_STATS",
+      statement: "SELECT COUNT(*) AS user_count FROM USERS",
+    });
+  });
+
+  test("parsing complex view with joins", () => {
+    const view = parseCreateViewScript(
+      "main",
+      `CREATE VIEW ORDER_DETAILS AS 
+       SELECT o.id, o.date, c.name, p.title 
+       FROM orders o 
+       JOIN customers c ON o.customer_id = c.id 
+       JOIN products p ON o.product_id = p.id;`
+    );
+    expect(view).toMatchObject({
+      schemaName: "main",
+      name: "ORDER_DETAILS",
+      statement: `SELECT o.id, o.date, c.name, p.title 
+       FROM orders o 
+       JOIN customers c ON o.customer_id = c.id 
+       JOIN products p ON o.product_id = p.id`,
+    });
+  });
+
+  test("parsing view with subquery", () => {
+    const view = parseCreateViewScript(
+      "analytics",
+      `CREATE VIEW TOP_CUSTOMERS AS 
+       SELECT customer_id, SUM(amount) as total 
+       FROM (SELECT * FROM transactions WHERE status = 'completed') 
+       GROUP BY customer_id 
+       ORDER BY total DESC;`
+    );
+    expect(view).toMatchObject({
+      schemaName: "analytics",
+      name: "TOP_CUSTOMERS",
+      statement: `SELECT customer_id, SUM(amount) as total 
+       FROM (SELECT * FROM transactions WHERE status = 'completed') 
+       GROUP BY customer_id 
+       ORDER BY total DESC`,
+    });
+  });
+});


### PR DESCRIPTION
Originally, we relied on CodeMirror's Lezer to build the AST and parsed from it. Now, we use our own tokenization approach. It produces a flat structure, and we build the parser on top of that. This gives us more flexibility for future extensions and reduces our dependency on external libraries.